### PR TITLE
Use `args` as an array not as a string

### DIFF
--- a/caddy-2/rootfs/usr/bin/caddy.sh
+++ b/caddy-2/rootfs/usr/bin/caddy.sh
@@ -145,7 +145,7 @@ main() {
 
     # Run Caddy
     bashio::log.info "Run Caddy..."
-    bashio::log.debug "'${CADDY_PATH}' run --config '${CONFIG_PATH}' '${ARGS}'"
-    "${CADDY_PATH}" run --config "${CONFIG_PATH}" "${ARGS}"
+    bashio::log.debug "'${CADDY_PATH}' run --config '${CONFIG_PATH}' '${ARGS[*]}'"
+    "${CADDY_PATH}" run --config "${CONFIG_PATH}" "${ARGS[@]}"
 }
 main "$@"

--- a/caddy-2/rootfs/usr/bin/caddy.sh
+++ b/caddy-2/rootfs/usr/bin/caddy.sh
@@ -113,7 +113,11 @@ main() {
 
     declare name
     declare value
-    ARGS=$(bashio::config 'args')
+    declare -a args=()
+
+    for arg in $(bashio::config 'args|keys'); do
+        args+=( $(bashio::config "args[${arg}]") )
+    done
 
     # Load custom environment variables
     for var in $(bashio::config 'env_vars|keys'); do
@@ -145,7 +149,7 @@ main() {
 
     # Run Caddy
     bashio::log.info "Run Caddy..."
-    bashio::log.debug "'${CADDY_PATH}' run --config '${CONFIG_PATH}' '${ARGS[*]}'"
-    "${CADDY_PATH}" run --config "${CONFIG_PATH}" "${ARGS[@]}"
+    bashio::log.debug "'${CADDY_PATH}' run --config '${CONFIG_PATH}' '${args[*]}'"
+    "${CADDY_PATH}" run --config "${CONFIG_PATH}" "${args[@]}"
 }
 main "$@"


### PR DESCRIPTION
The `args` config accepts an array of strings. But when it uses it it treats it like a single string config by doing `${ARGS}`. It should be treating it like an array in the run statement of Caddy so all elements of the args array are passed in as individual arguments to `caddy`.

I discovered this when I tried to build a custom Caddy binary that included the [caddy-yaml](https://github.com/abiosoft/caddy-yaml) plug-in. To use this plug-in you write the caddy file in YAML and then pass the arguments `--adapter  yaml` to the run command. I set my configuration up like this to try it:

```yaml
config_path: /share/caddy/Caddyfile.yaml
args:
  - '--watch'
  - '--adapter'
  - yaml
```

When I did I got this with debug logging the problem became obvious:

```
DEBUG: '/share/caddy/caddy' run --config '/share/caddy/Caddyfile.yaml' '--watch
--adapter
yaml'
flag provided but not defined: -watch
--adapter
yaml
```

Looping over args and building an array like `env_vars` seems to fix the problem in my local testing.

